### PR TITLE
 Compose for tv beta migration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -134,7 +134,7 @@ dependencies {
     debugImplementation(libs.ui.tooling)
     debugImplementation(libs.ui.test.manifest)
 
-    implementation(libs.tv.foundation)
+    // implementation(libs.tv.foundation)
     implementation(libs.tv.material)
 
     implementation(libs.navigation.compose)

--- a/app/src/main/kotlin/com/muedsa/compose/tv/Modifier.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/Modifier.kt
@@ -1,12 +1,23 @@
 package com.muedsa.compose.tv
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.relocation.BringIntoViewResponder
+import androidx.compose.foundation.relocation.bringIntoViewResponder
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.unit.toSize
 
 inline fun Modifier.conditional(
     condition: Boolean,
@@ -51,3 +62,40 @@ fun Modifier.focusOnMount(itemKey: String): Modifier {
             }
         }
 }
+
+@Suppress("IllegalExperimentalApiUsage") // TODO (b/233188423): Address before moving to beta
+@OptIn(ExperimentalFoundationApi::class)
+// ToDo: Migrate to Modifier.Node and stop using composed function.
+internal fun Modifier.bringIntoViewIfChildrenAreFocused(
+    paddingValues: PaddingValues = PaddingValues()
+): Modifier = composed(
+    inspectorInfo = debugInspectorInfo { name = "bringIntoViewIfChildrenAreFocused" },
+    factory = {
+        val pxOffset = with(LocalDensity.current) {
+            val y = (paddingValues.calculateBottomPadding() - paddingValues.calculateTopPadding())
+                .toPx()
+            Offset.Zero.copy(y = y)
+        }
+        var myRect: Rect = Rect.Zero
+        val responder = object : BringIntoViewResponder {
+            // return the current rectangle and ignoring the child rectangle received.
+            @ExperimentalFoundationApi
+            override fun calculateRectForParent(localRect: Rect): Rect {
+                return myRect
+            }
+
+            // The container is not expected to be scrollable. Hence the child is
+            // already in view with respect to the container.
+            @ExperimentalFoundationApi
+            override suspend fun bringChildIntoView(localRect: () -> Rect?) {
+            }
+        }
+
+        this
+            .onSizeChanged {
+                val size = it.toSize()
+                myRect = Rect(pxOffset, size)
+            }
+            .bringIntoViewResponder(responder)
+    }
+)

--- a/app/src/main/kotlin/com/muedsa/compose/tv/theme/Color.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/theme/Color.kt
@@ -2,12 +2,12 @@ package com.muedsa.compose.tv.theme
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.tv.foundation.lazy.list.TvLazyColumn
 import androidx.tv.material3.ColorScheme
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
@@ -46,7 +46,7 @@ val ColorScheme.outlineVariant: Color
 
 @Composable
 fun TvColorPreview(modifier: Modifier = Modifier) {
-    TvLazyColumn(modifier) {
+    LazyColumn(modifier) {
         item {
             Text(
                 modifier = Modifier

--- a/app/src/main/kotlin/com/muedsa/compose/tv/theme/Color.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/theme/Color.kt
@@ -9,13 +9,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.tv.foundation.lazy.list.TvLazyColumn
 import androidx.tv.material3.ColorScheme
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import androidx.tv.material3.darkColorScheme
 
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 val TvDarkColorScheme = darkColorScheme(
 //    background = background,
 //    onBackground = onBackground,
@@ -25,35 +23,27 @@ val TvDarkColorScheme = darkColorScheme(
 //    onSurfaceVariant = onSurfaceVariant
 )
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 val ColorScheme.surfaceContainerLowest: Color
     get() = Color(red = 14, green = 14, blue = 14) // N-4 0E0E0E
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 val ColorScheme.surfaceContainerLowe: Color
     get() = Color(red = 27, green = 27, blue = 27) // N-10 1B1B1B
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 val ColorScheme.surfaceContainer: Color
     get() = Color(red = 30, green = 31, blue = 32) // N-12 1E1F20
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 val ColorScheme.surfaceContainerHigh: Color
     get() = Color(red = 40, green = 42, blue = 44) // N-17 282A2C
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 val ColorScheme.surfaceContainerHighest: Color
     get() = Color(red = 51, green = 53, blue = 55) // N-22 333537
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 val ColorScheme.outline: Color
     get() = Color(red = 147, green = 143, blue = 153) // PaletteTokens.NeutralVariant60
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 val ColorScheme.outlineVariant: Color
     get() = Color(red = 73, green = 69, blue = 79) // PaletteTokens.NeutralVariant30
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 fun TvColorPreview(modifier: Modifier = Modifier) {
     TvLazyColumn(modifier) {

--- a/app/src/main/kotlin/com/muedsa/compose/tv/theme/Theme.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/theme/Theme.kt
@@ -1,11 +1,9 @@
 package com.muedsa.compose.tv.theme
 
 import androidx.compose.runtime.Composable
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 fun TvTheme(
     content: @Composable () -> Unit

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/ContentBlock.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/ContentBlock.kt
@@ -1,6 +1,5 @@
 package com.muedsa.compose.tv.widget
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -10,13 +9,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.muedsa.compose.tv.model.ContentModel
 import com.muedsa.compose.tv.theme.TvTheme
 
-@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun ContentBlock(
     modifier: Modifier = Modifier,

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/ErrorMessageBox.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/ErrorMessageBox.kt
@@ -27,12 +27,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.unit.dp
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun ErrorMessageBox(
     state: ErrorMessageBoxController = remember { ErrorMessageBoxController() },

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/FullScreenWidgets.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/FullScreenWidgets.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.OutlinedIconButton
@@ -40,7 +39,7 @@ fun EmptyDataScreen(model: Boolean = false) {
     FillTextScreen(context = "Empty(っ °Д °;)っ", model = model)
 }
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun ErrorScreen(onRefresh: (() -> Unit)? = null) {
     Column(
@@ -60,7 +59,7 @@ fun ErrorScreen(onRefresh: (() -> Unit)? = null) {
     }
 }
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun FillTextScreen(context: String, model: Boolean = false) {
     var modifier = Modifier.fillMaxSize()

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/ImageCard.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/ImageCard.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Card
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import com.muedsa.compose.tv.model.ContentModel
@@ -92,7 +91,7 @@ enum class CardType {
     WIDE_STANDARD
 }
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun ImageCard(
     modifier: Modifier = Modifier,

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/ImageCardsRow.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/ImageCardsRow.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.unit.dp
 import androidx.tv.foundation.lazy.list.TvLazyListState
 import androidx.tv.foundation.lazy.list.TvLazyRow
 import androidx.tv.foundation.lazy.list.rememberTvLazyListState
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.muedsa.compose.tv.model.ContentModel
@@ -34,7 +33,7 @@ import com.muedsa.compose.tv.theme.VerticalPosterSize
 import com.muedsa.uitl.anyMatchWithIndex
 
 
-@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun <T> ImageCardsRow(
     modifier: Modifier = Modifier,
@@ -99,7 +98,7 @@ fun <T> ImageCardsRow(
     }
 }
 
-@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun <T> StandardImageCardsRow(
     modifier: Modifier = Modifier,

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/ImageCardsRow.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/ImageCardsRow.kt
@@ -6,6 +6,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -18,9 +21,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import androidx.tv.foundation.lazy.list.TvLazyListState
-import androidx.tv.foundation.lazy.list.TvLazyRow
-import androidx.tv.foundation.lazy.list.rememberTvLazyListState
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.muedsa.compose.tv.model.ContentModel
@@ -37,7 +37,7 @@ import com.muedsa.uitl.anyMatchWithIndex
 @Composable
 fun <T> ImageCardsRow(
     modifier: Modifier = Modifier,
-    state: TvLazyListState = rememberTvLazyListState(),
+    state: LazyListState = rememberLazyListState(),
     title: String,
     modelList: List<T> = listOf(),
     imageFn: (index: Int, item: T) -> String,
@@ -59,7 +59,7 @@ fun <T> ImageCardsRow(
             maxLines = 1
         )
         Spacer(modifier = Modifier.height(ImageCardRowCardPadding))
-        TvLazyRow(
+        LazyRow(
             modifier = Modifier
                 .focusRequester(rowFR)
                 .focusRestorer {
@@ -102,7 +102,7 @@ fun <T> ImageCardsRow(
 @Composable
 fun <T> StandardImageCardsRow(
     modifier: Modifier = Modifier,
-    state: TvLazyListState = rememberTvLazyListState(),
+    state: LazyListState = rememberLazyListState(),
     title: String,
     modelList: List<T> = listOf(),
     imageFn: (index: Int, item: T) -> String,
@@ -129,7 +129,7 @@ fun <T> StandardImageCardsRow(
             maxLines = 1
         )
         Spacer(modifier = Modifier.height(10.dp))
-        TvLazyRow(
+        LazyRow(
             modifier = Modifier
                 .focusRequester(rowFR)
                 .focusRestorer {

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/ImmersiveList.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/ImmersiveList.kt
@@ -1,0 +1,26 @@
+package com.muedsa.compose.tv.widget
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.muedsa.compose.tv.bringIntoViewIfChildrenAreFocused
+
+/**
+ * A replacement for ImmersiveList.
+ */
+@Composable
+fun ImmersiveList(
+    modifier: Modifier = Modifier,
+    background: @Composable BoxScope.() -> Unit,
+    list: @Composable BoxScope.() -> Unit
+) {
+    Box(modifier.bringIntoViewIfChildrenAreFocused()) {
+        background()
+        Box(
+            contentAlignment = Alignment.BottomEnd,
+            content = list
+        )
+    }
+}

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/OutlinedIconBox.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/OutlinedIconBox.kt
@@ -20,15 +20,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Border
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.NonInteractiveSurfaceDefaults
 import androidx.tv.material3.OutlinedIconButtonDefaults
 import androidx.tv.material3.Surface
+import androidx.tv.material3.SurfaceDefaults
 import com.muedsa.compose.tv.theme.TvTheme
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 fun OutlinedIconBox(
     modifier: Modifier = Modifier,
@@ -48,7 +46,7 @@ fun OutlinedIconBox(
             ),
             shape = CircleShape
         ),
-        colors = NonInteractiveSurfaceDefaults.colors(
+        colors = SurfaceDefaults.colors(
             containerColor = if (inverse) MaterialTheme.colorScheme.onSurface else Color.Transparent,
             contentColor = if (inverse) MaterialTheme.colorScheme.inverseOnSurface else MaterialTheme.colorScheme.onSurface,
         )
@@ -61,7 +59,6 @@ fun OutlinedIconBox(
     }
 }
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 @Preview
 @Composable
 fun OutlinedIconBoxPreview() {

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/RightSideDrawer.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/RightSideDrawer.kt
@@ -11,21 +11,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.DrawerState
 import androidx.tv.material3.DrawerValue
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.ModalNavigationDrawer
 import androidx.tv.material3.NonInteractiveSurfaceDefaults
 import androidx.tv.material3.Surface
 import com.muedsa.compose.tv.theme.surfaceContainer
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun RightSideDrawer(
     controller: RightSideDrawerController = RightSideDrawerController(),
@@ -79,7 +77,6 @@ fun RightSideDrawer(
 }
 
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 open class RightSideDrawerController {
     private val contentState: MutableState<@Composable () -> Unit> = mutableStateOf({})
     val drawerState: DrawerState = DrawerState(DrawerValue.Closed)

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/RightSideDrawer.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/RightSideDrawer.kt
@@ -19,8 +19,8 @@ import androidx.tv.material3.DrawerState
 import androidx.tv.material3.DrawerValue
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.ModalNavigationDrawer
-import androidx.tv.material3.NonInteractiveSurfaceDefaults
 import androidx.tv.material3.Surface
+import androidx.tv.material3.SurfaceDefaults
 import com.muedsa.compose.tv.theme.surfaceContainer
 
 
@@ -46,7 +46,7 @@ fun RightSideDrawer(
                             Surface(
                                 modifier = Modifier
                                     .fillMaxHeight(),
-                                colors = NonInteractiveSurfaceDefaults.colors(
+                                colors = SurfaceDefaults.colors(
                                     containerColor = MaterialTheme.colorScheme.surfaceContainer,
                                     contentColor = MaterialTheme.colorScheme.onSurface
                                 )

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/RightSideDrawerWithNav.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/RightSideDrawerWithNav.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.SecureFlagPolicy
 import androidx.navigation.NavController
 import androidx.tv.material3.DrawerValue
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.NonInteractiveSurfaceDefaults
 import androidx.tv.material3.Surface
@@ -32,7 +31,7 @@ fun FullWidthDialogProperties(
     decorFitsSystemWindows = decorFitsSystemWindows,
 )
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun RightSideDrawerWithNavDrawerContent(
     controller: RightSideDrawerController

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/RightSideDrawerWithNav.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/RightSideDrawerWithNav.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.window.SecureFlagPolicy
 import androidx.navigation.NavController
 import androidx.tv.material3.DrawerValue
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.NonInteractiveSurfaceDefaults
 import androidx.tv.material3.Surface
+import androidx.tv.material3.SurfaceDefaults
 import com.muedsa.compose.tv.theme.surfaceContainer
 
 fun FullWidthDialogProperties(
@@ -46,7 +46,7 @@ fun RightSideDrawerWithNavDrawerContent(
             Surface(
                 modifier = Modifier
                     .fillMaxHeight(),
-                colors = NonInteractiveSurfaceDefaults.colors(
+                colors = SurfaceDefaults.colors(
                     containerColor = MaterialTheme.colorScheme.surfaceContainer,
                     contentColor = MaterialTheme.colorScheme.onSurface
                 )

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/Scaffold.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/Scaffold.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.NonInteractiveSurfaceColors
 import androidx.tv.material3.NonInteractiveSurfaceDefaults
@@ -13,7 +12,7 @@ import androidx.tv.material3.Surface
 import com.muedsa.compose.tv.LocalErrorMsgBoxControllerProvider
 import com.muedsa.compose.tv.LocalRightSideDrawerControllerProvider
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun Scaffold(
     holdBack: Boolean = true,

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/Scaffold.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/Scaffold.kt
@@ -6,9 +6,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.NonInteractiveSurfaceColors
-import androidx.tv.material3.NonInteractiveSurfaceDefaults
 import androidx.tv.material3.Surface
+import androidx.tv.material3.SurfaceColors
+import androidx.tv.material3.SurfaceDefaults
 import com.muedsa.compose.tv.LocalErrorMsgBoxControllerProvider
 import com.muedsa.compose.tv.LocalRightSideDrawerControllerProvider
 
@@ -16,7 +16,7 @@ import com.muedsa.compose.tv.LocalRightSideDrawerControllerProvider
 @Composable
 fun Scaffold(
     holdBack: Boolean = true,
-    colors: NonInteractiveSurfaceColors = NonInteractiveSurfaceDefaults.colors(
+    colors: SurfaceColors = SurfaceDefaults.colors(
         containerColor = MaterialTheme.colorScheme.background,
         contentColor = MaterialTheme.colorScheme.onBackground
     ),

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/ScreenBackground.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/ScreenBackground.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
@@ -34,7 +33,7 @@ import jp.wasabeef.transformers.coil.BlurTransformation
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun ScreenBackground(
     state: ScreenBackgroundState = rememberScreenBackgroundState()

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/SwitchKt.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/SwitchKt.kt
@@ -9,12 +9,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Switch
 import androidx.tv.material3.SwitchColors
 import androidx.tv.material3.SwitchDefaults
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun FocusScaleSwitch(
     checked: Boolean,

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/WideButton.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/WideButton.kt
@@ -22,7 +22,6 @@ import androidx.tv.material3.ButtonBorder
 import androidx.tv.material3.ButtonGlow
 import androidx.tv.material3.ButtonScale
 import androidx.tv.material3.ButtonShape
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.ProvideTextStyle
@@ -30,7 +29,7 @@ import androidx.tv.material3.WideButton
 import androidx.tv.material3.WideButtonContentColor
 import androidx.tv.material3.WideButtonDefaults
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun TwoSideWideButton(
     onClick: () -> Unit,
@@ -108,7 +107,7 @@ fun TwoSideWideButton(
     }
 }
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun WideButtonDefaults.NoBackground(interactionSource: InteractionSource) {
     val isFocused = interactionSource.collectIsFocusedAsState().value

--- a/app/src/main/kotlin/com/muedsa/compose/tv/widget/player/PlayerControl.kt
+++ b/app/src/main/kotlin/com/muedsa/compose/tv/widget/player/PlayerControl.kt
@@ -43,7 +43,6 @@ import androidx.media3.common.Format
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.UnstableApi
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
@@ -55,7 +54,6 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
-@kotlin.OptIn(ExperimentalTvMaterial3Api::class)
 @OptIn(UnstableApi::class)
 @Composable
 fun PlayerControl(
@@ -238,7 +236,6 @@ fun PlayerControl(
     }
 }
 
-@kotlin.OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 fun PlayerProgressIndicator(player: Player) {
     val dateTimeFormat = remember { SimpleDateFormat.getDateTimeInstance() }

--- a/app/src/main/kotlin/com/muedsa/jcytv/MainActivity.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/MainActivity.kt
@@ -5,7 +5,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import com.muedsa.compose.tv.theme.TvTheme
 import com.muedsa.compose.tv.widget.Scaffold
 import com.muedsa.jcytv.ui.nav.AppNavigation
@@ -18,7 +17,6 @@ class MainActivity : ComponentActivity() {
 
     private val homePageViewModel: HomePageViewModel by viewModels()
 
-    @OptIn(ExperimentalTvMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/muedsa/jcytv/PlaybackActivity.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/PlaybackActivity.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.NonInteractiveSurfaceDefaults
 import androidx.tv.material3.Surface
@@ -24,7 +23,6 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class PlaybackActivity : ComponentActivity() {
 
-    @OptIn(ExperimentalTvMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/app/src/main/kotlin/com/muedsa/jcytv/PlaybackActivity.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/PlaybackActivity.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.NonInteractiveSurfaceDefaults
 import androidx.tv.material3.Surface
+import androidx.tv.material3.SurfaceDefaults
 import com.muedsa.compose.tv.theme.TvTheme
 import com.muedsa.compose.tv.useLocalErrorMsgBoxController
 import com.muedsa.compose.tv.widget.AppBackHandler
@@ -34,7 +34,7 @@ class PlaybackActivity : ComponentActivity() {
             TvTheme {
                 Scaffold(
                     holdBack = false,
-                    colors = NonInteractiveSurfaceDefaults.colors(
+                    colors = SurfaceDefaults.colors(
                         containerColor = Color.Black,
                         contentColor = MaterialTheme.colorScheme.onBackground
                     )

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/detail/AnimeDanmakuSelectorWidget.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/detail/AnimeDanmakuSelectorWidget.kt
@@ -1,6 +1,5 @@
 package com.muedsa.jcytv.ui.features.detail
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -29,7 +28,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.tv.foundation.lazy.list.TvLazyColumn
 import androidx.tv.foundation.lazy.list.items
 import androidx.tv.material3.Button
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.OutlinedIconButton
@@ -42,7 +40,7 @@ import com.muedsa.compose.tv.widget.NoBackground
 import com.muedsa.compose.tv.widget.TwoSideWideButton
 import com.muedsa.jcytv.viewmodel.AnimeDetailViewModel
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun AnimeDanmakuSelectBtnWidget(
     enabledDanmakuState: MutableState<Boolean> = remember { mutableStateOf(false) },
@@ -62,7 +60,6 @@ fun AnimeDanmakuSelectBtnWidget(
     }
 }
 
-@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun DanmakuSelectorSideWidget(
     enabledDanmakuState: MutableState<Boolean> = remember { mutableStateOf(false) },

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/detail/AnimeDanmakuSelectorWidget.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/detail/AnimeDanmakuSelectorWidget.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.OutlinedTextField
@@ -25,8 +27,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.tv.foundation.lazy.list.TvLazyColumn
-import androidx.tv.foundation.lazy.list.items
 import androidx.tv.material3.Button
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
@@ -83,7 +83,7 @@ fun DanmakuSelectorSideWidget(
                 text = "弹幕剧集",
                 style = MaterialTheme.typography.titleLarge
             )
-            TvLazyColumn(
+            LazyColumn(
                 contentPadding = PaddingValues(vertical = 20.dp)
             ) {
                 item {

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/detail/AnimeDetailScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/detail/AnimeDetailScreen.kt
@@ -1,7 +1,6 @@
 package com.muedsa.jcytv.ui.features.detail
 
 import android.content.Intent
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -39,7 +38,6 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.tv.foundation.lazy.list.TvLazyColumn
 import androidx.tv.foundation.lazy.list.items
 import androidx.tv.material3.ButtonDefaults
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.MaterialTheme
@@ -76,7 +74,6 @@ import com.muedsa.jcytv.viewmodel.AppSettingViewModel
 import com.muedsa.model.LazyType
 import com.muedsa.uitl.LogUtil
 
-@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun AnimeDetailScreen(
     viewModel: AnimeDetailViewModel = hiltViewModel(),

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/detail/AnimeDetailScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/detail/AnimeDetailScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Edit
@@ -35,8 +37,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import androidx.tv.foundation.lazy.list.TvLazyColumn
-import androidx.tv.foundation.lazy.list.items
 import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.Icon
 import androidx.tv.material3.LocalContentColor
@@ -156,7 +156,7 @@ fun AnimeDetailScreen(
 
             val enabledDanmakuState = remember { mutableStateOf(true) }
 
-            TvLazyColumn(
+            LazyColumn(
                 modifier = Modifier
                     .padding(start = ScreenPaddingLeft),
                 contentPadding = PaddingValues(bottom = 100.dp)
@@ -222,7 +222,7 @@ fun AnimeDetailScreen(
                                         text = "弹幕剧集",
                                         style = MaterialTheme.typography.titleLarge
                                     )
-                                    TvLazyColumn(
+                                    LazyColumn(
                                         contentPadding = PaddingValues(vertical = 20.dp)
                                     ) {
                                         items(items = animeDetail.playList) {

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/detail/EpisodeListWidget.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/detail/EpisodeListWidget.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -25,8 +27,6 @@ import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.tv.foundation.lazy.list.TvLazyRow
-import androidx.tv.foundation.lazy.list.itemsIndexed
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import androidx.tv.material3.WideButton
@@ -93,7 +93,7 @@ fun EpisodeListWidget(
                     }
 
                     // 剧集列表
-                    TvLazyRow {
+                    LazyRow {
                         itemsIndexed(
                             items = currentPartEpisodeList,
                             key = { _, item -> item.first }
@@ -235,7 +235,7 @@ fun EpisodeListWidget(
                         }
                     }
 
-                    TvLazyRow {
+                    LazyRow {
                         itemsIndexed(
                             items = danEpisodeList,
                             key = { _, item -> item.episodeId }

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/detail/EpisodeListWidget.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/detail/EpisodeListWidget.kt
@@ -2,7 +2,6 @@ package com.muedsa.jcytv.ui.features.detail
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.Crossfade
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
@@ -28,7 +27,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.tv.foundation.lazy.list.TvLazyRow
 import androidx.tv.foundation.lazy.list.itemsIndexed
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import androidx.tv.material3.WideButton
@@ -41,7 +39,6 @@ const val EpisodePageSize = 20
 val EpisodeProgressStrokeWidth = 12.dp
 val WideButtonCornerRadius = 12.dp
 
-@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun EpisodeListWidget(
     modifier: Modifier = Modifier,

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/HomeNavTabWidget.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/HomeNavTabWidget.kt
@@ -1,6 +1,7 @@
 package com.muedsa.jcytv.ui.features.home
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -51,7 +52,7 @@ fun HomeNavTabWidget(
         tabPanelIndex = selectedTabIndex
     }
 
-    Column {
+    Column(modifier = Modifier.fillMaxWidth()) {
         TabRow(
             modifier = Modifier
                 .align(alignment = Alignment.CenterHorizontally)

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/HomeNavTabWidget.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/HomeNavTabWidget.kt
@@ -1,7 +1,6 @@
 package com.muedsa.jcytv.ui.features.home
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -10,6 +9,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusRestorer
@@ -54,7 +54,7 @@ fun HomeNavTabWidget(
     Column {
         TabRow(
             modifier = Modifier
-                .fillMaxWidth()
+                .align(alignment = Alignment.CenterHorizontally)
                 .padding(top = 24.dp, bottom = 24.dp)
                 .focusRestorer(),
             selectedTabIndex = selectedTabIndex,

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/HomeNavTabWidget.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/HomeNavTabWidget.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Tab
 import androidx.tv.material3.TabDefaults
@@ -35,7 +34,7 @@ import kotlin.time.Duration.Companion.milliseconds
 
 val tabs: Array<HomeNavTab> = HomeNavTab.entries.toTypedArray()
 
-@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun HomeNavTabWidget(
     tabIndex: Int = 0,

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/catalog/CatalogScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/catalog/CatalogScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -37,7 +36,6 @@ import androidx.tv.foundation.lazy.grid.itemsIndexed
 import androidx.tv.foundation.lazy.list.TvLazyColumn
 import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.Card
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.OutlinedIconButton
@@ -59,7 +57,6 @@ import com.muedsa.jcytv.viewmodel.CatalogViewModel
 import com.muedsa.model.LazyType
 import com.muedsa.uitl.LogUtil
 
-@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun CatalogScreen(
     viewModel: CatalogViewModel = hiltViewModel()

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/catalog/CatalogScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/catalog/CatalogScreen.kt
@@ -13,6 +13,10 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowDropDown
 import androidx.compose.material.icons.outlined.KeyboardArrowUp
@@ -30,10 +34,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.tv.foundation.lazy.grid.TvGridCells
-import androidx.tv.foundation.lazy.grid.TvLazyVerticalGrid
-import androidx.tv.foundation.lazy.grid.itemsIndexed
-import androidx.tv.foundation.lazy.list.TvLazyColumn
 import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.Card
 import androidx.tv.material3.Icon
@@ -123,7 +123,7 @@ fun CatalogScreen(
 
         if (optionsExpand) {
             // 筛选项
-            TvLazyColumn(contentPadding = PaddingValues(top = ImageCardRowCardPadding)) {
+            LazyColumn(contentPadding = PaddingValues(top = ImageCardRowCardPadding)) {
                 item {
                     CatalogOptionsWidget(
                         title = "频道",
@@ -205,8 +205,8 @@ fun CatalogScreen(
         } else {
             val gridFocusRequester = remember { FocusRequester() }
 
-            TvLazyVerticalGrid(
-                columns = TvGridCells.Adaptive(VideoPosterSize.width + ImageCardRowCardPadding),
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(VideoPosterSize.width + ImageCardRowCardPadding),
                 contentPadding = PaddingValues(
                     top = ImageCardRowCardPadding,
                     bottom = ImageCardRowCardPadding

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/favorites/FavoritesScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/favorites/FavoritesScreen.kt
@@ -26,7 +26,6 @@ import androidx.tv.foundation.lazy.grid.TvGridCells
 import androidx.tv.foundation.lazy.grid.TvLazyVerticalGrid
 import androidx.tv.foundation.lazy.grid.itemsIndexed
 import androidx.tv.material3.ButtonDefaults
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.OutlinedButton
@@ -45,7 +44,7 @@ import com.muedsa.jcytv.ui.nav.navigate
 import com.muedsa.jcytv.viewmodel.FavoriteViewModel
 import com.muedsa.uitl.LogUtil
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun FavoritesScreen(
     viewModel: FavoriteViewModel = hiltViewModel()

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/favorites/FavoritesScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/favorites/FavoritesScreen.kt
@@ -7,6 +7,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.Delete
@@ -22,9 +25,6 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.tv.foundation.lazy.grid.TvGridCells
-import androidx.tv.foundation.lazy.grid.TvLazyVerticalGrid
-import androidx.tv.foundation.lazy.grid.itemsIndexed
 import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
@@ -83,10 +83,10 @@ fun FavoritesScreen(
             }
         }
 
-        TvLazyVerticalGrid(
+        LazyVerticalGrid(
             modifier = Modifier
                 .padding(start = 0.dp, top = 20.dp, end = 20.dp, bottom = 20.dp),
-            columns = TvGridCells.Adaptive(VideoPosterSize.width + ImageCardRowCardPadding),
+            columns = GridCells.Adaptive(VideoPosterSize.width + ImageCardRowCardPadding),
             contentPadding = PaddingValues(
                 top = ImageCardRowCardPadding,
                 bottom = ImageCardRowCardPadding

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/main/MainScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/main/MainScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.tv.material3.ImmersiveList
 import androidx.tv.material3.MaterialTheme
 import com.muedsa.compose.tv.model.ContentModel
 import com.muedsa.compose.tv.theme.ImageCardRowCardPadding
@@ -29,6 +28,7 @@ import com.muedsa.compose.tv.useLocalNavHostController
 import com.muedsa.compose.tv.widget.ContentBlock
 import com.muedsa.compose.tv.widget.ErrorScreen
 import com.muedsa.compose.tv.widget.ImageCardsRow
+import com.muedsa.compose.tv.widget.ImmersiveList
 import com.muedsa.compose.tv.widget.LoadingScreen
 import com.muedsa.compose.tv.widget.ScreenBackgroundType
 import com.muedsa.compose.tv.widget.StandardImageCardsRow
@@ -93,7 +93,7 @@ fun MainScreen(
                     }
                 }
                 ImmersiveList(
-                    background = { _, _ ->
+                    background = {
                         ContentBlock(
                             modifier = Modifier
                                 .width(screenWidth / 2)

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/main/MainScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/main/MainScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -18,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.tv.foundation.lazy.list.TvLazyColumn
 import androidx.tv.material3.ImmersiveList
 import androidx.tv.material3.MaterialTheme
 import com.muedsa.compose.tv.model.ContentModel
@@ -73,7 +73,7 @@ fun MainScreen(
 
     if (homeRowsLD.type == LazyType.SUCCESS && !homeRowsLD.data.isNullOrEmpty()) {
         val homeRows = homeRowsLD.data!!
-        TvLazyColumn(
+        LazyColumn(
             modifier = Modifier
                 .offset(x = ScreenPaddingLeft - ImageCardRowCardPadding),
             contentPadding = PaddingValues(bottom = 100.dp)

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/main/MainScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/main/MainScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.tv.foundation.lazy.list.TvLazyColumn
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.ImmersiveList
 import androidx.tv.material3.MaterialTheme
 import com.muedsa.compose.tv.model.ContentModel
@@ -41,7 +40,7 @@ import com.muedsa.jcytv.viewmodel.HomePageViewModel
 import com.muedsa.model.LazyType
 import com.muedsa.uitl.LogUtil
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun MainScreen(
     viewModel: HomePageViewModel = hiltViewModel(),

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/rank/RankAnimeWidget.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/rank/RankAnimeWidget.kt
@@ -1,6 +1,5 @@
 package com.muedsa.jcytv.ui.features.home.rank
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
@@ -16,13 +15,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Card
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.muedsa.compose.tv.conditional
 import com.muedsa.jcytv.model.JcyRankVideoInfo
 
-@OptIn(ExperimentalTvMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun RankAnimeWidget(
     model: JcyRankVideoInfo,

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/rank/RankScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/rank/RankScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -14,8 +16,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.tv.foundation.lazy.list.TvLazyColumn
-import androidx.tv.foundation.lazy.list.items
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.muedsa.compose.tv.theme.ScreenPaddingLeft
@@ -63,7 +63,7 @@ fun RankScreen(
                             color = MaterialTheme.colorScheme.onBackground,
                             style = MaterialTheme.typography.titleLarge
                         )
-                        TvLazyColumn {
+                        LazyColumn {
                             items(rank.second) {
                                 RankAnimeWidget(
                                     model = it,

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/rank/RankScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/rank/RankScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.tv.foundation.lazy.list.TvLazyColumn
 import androidx.tv.foundation.lazy.list.items
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.muedsa.compose.tv.theme.ScreenPaddingLeft
@@ -31,7 +30,7 @@ import com.muedsa.model.LazyType
 import com.muedsa.uitl.LogUtil
 import kotlin.math.min
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun RankScreen(
     viewModel: RankViewModel = hiltViewModel()

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/search/SearchScreen.kt
@@ -12,6 +12,9 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.OutlinedTextField
@@ -27,9 +30,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.tv.foundation.lazy.grid.TvGridCells
-import androidx.tv.foundation.lazy.grid.TvLazyVerticalGrid
-import androidx.tv.foundation.lazy.grid.itemsIndexed
 import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
@@ -115,8 +115,8 @@ fun SearchScreen(
             val animeList = searchAnimeLD.data!!
             val gridFocusRequester = remember { FocusRequester() }
 
-            TvLazyVerticalGrid(
-                columns = TvGridCells.Adaptive(VideoPosterSize.width + ImageCardRowCardPadding),
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(VideoPosterSize.width + ImageCardRowCardPadding),
                 contentPadding = PaddingValues(
                     top = ImageCardRowCardPadding,
                     bottom = ImageCardRowCardPadding

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/home/search/SearchScreen.kt
@@ -31,7 +31,6 @@ import androidx.tv.foundation.lazy.grid.TvGridCells
 import androidx.tv.foundation.lazy.grid.TvLazyVerticalGrid
 import androidx.tv.foundation.lazy.grid.itemsIndexed
 import androidx.tv.material3.ButtonDefaults
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.OutlinedIconButton
@@ -53,7 +52,7 @@ import com.muedsa.jcytv.viewmodel.SearchViewModel
 import com.muedsa.model.LazyType
 import com.muedsa.uitl.LogUtil
 
-@OptIn(ExperimentalTvMaterial3Api::class)
+
 @Composable
 fun SearchScreen(
     viewModel: SearchViewModel = hiltViewModel()

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/setting/AppSettingScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/setting/AppSettingScreen.kt
@@ -24,9 +24,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.NonInteractiveSurfaceDefaults
 import androidx.tv.material3.OutlinedIconButton
 import androidx.tv.material3.Surface
+import androidx.tv.material3.SurfaceDefaults
 import androidx.tv.material3.Text
 import com.muedsa.compose.tv.theme.surfaceContainer
 import com.muedsa.compose.tv.useLocalErrorMsgBoxController
@@ -58,7 +58,7 @@ fun AppSettingScreen(
             Surface(
                 modifier = Modifier
                     .fillMaxHeight(),
-                colors = NonInteractiveSurfaceDefaults.colors(
+                colors = SurfaceDefaults.colors(
                     containerColor = MaterialTheme.colorScheme.surfaceContainer,
                     contentColor = MaterialTheme.colorScheme.onSurface
                 )

--- a/app/src/main/kotlin/com/muedsa/jcytv/ui/features/setting/AppSettingScreen.kt
+++ b/app/src/main/kotlin/com/muedsa/jcytv/ui/features/setting/AppSettingScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.NonInteractiveSurfaceDefaults
@@ -35,7 +34,6 @@ import com.muedsa.compose.tv.widget.FocusScaleSwitch
 import com.muedsa.jcytv.viewmodel.AppSettingViewModel
 import com.muedsa.model.LazyType
 
-@OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 fun AppSettingScreen(
     viewModel: AppSettingViewModel = hiltViewModel()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,8 +7,9 @@ core-splashscreen = "1.0.1"
 lifecycle = "2.8.3"
 hilt = "2.51.1"
 activity-compose = "1.9.0"
-compose-bom = "2024.06.00"
-androidx-tv = "1.0.0-alpha10"
+compose-bom = "2024.07.00-alpha01"
+androidx-tv-foundation = "1.0.0-alpha11"
+androidx-tv-material = "1.0.0-rc01"
 navigation-compose = "2.7.7"
 hilt-navigation-compose = "1.2.0"
 coil = "2.6.0"
@@ -39,7 +40,7 @@ lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+compose-bom = { group = "dev.chrisbanes.compose", name = "compose-bom", version.ref = "compose-bom" }
 runtime = { group = "androidx.compose.runtime", name = "runtime" }
 ui = { group = "androidx.compose.ui", name = "ui" }
 ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
@@ -49,8 +50,8 @@ ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 material3 = { group = "androidx.compose.material3", name = "material3" }
 material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
-tv-foundation = { group = "androidx.tv", name = "tv-foundation", version.ref = "androidx-tv" }
-tv-material = { group = "androidx.tv", name = "tv-material", version.ref = "androidx-tv" }
+tv-foundation = { group = "androidx.tv", name = "tv-foundation", version.ref = "androidx-tv-foundation" }
+tv-material = { group = "androidx.tv", name = "tv-material", version.ref = "androidx-tv-material" }
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation-compose" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
 coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }


### PR DESCRIPTION
Compose TV 依赖已更新到`1.0.0-rc01` 处于正式发布的候选阶段, 但同时更改了很多API。
参考: https://github.com/android/tv-samples/pull/168
- [x] 更新依赖
- [x] 移除TV的实验性标记
- [x] 某些API被重名命, 更新这些API
- [x] 迁移TvLazyLayout(参考: https://issuetracker.google.com/issues/348896032)
- [x] 重新实现ImmersiveList
- [x] 其他调整与代码清理
- [x] 移除tv-foundation依赖